### PR TITLE
fix #56 verification JSONPath for 9.3.0, 9.4.0 SOLR-17072

### DIFF
--- a/repo/repository.json
+++ b/repo/repository.json
@@ -248,7 +248,7 @@
               "verify-command": {
                 "path": "/api/collections/${collection}/config/requestHandler?componentName=${RH-HANDLER-PATH}&meta=true",
                 "method": "GET",
-                "condition": "$[config].[requestHandler].[HANDLER-PATH].[_packageinfo_].[version]",
+                "condition": "$['config'].['requestHandler'].['${RH-HANDLER-PATH}'].['_packageinfo_'].['version']",
                 "expected": "${package-version}"
               }
             }
@@ -299,7 +299,7 @@
               "verify-command": {
                 "path": "/api/collections/${collection}/config/requestHandler?componentName=${RH-HANDLER-PATH}&meta=true",
                 "method": "GET",
-                "condition": "$[config].[requestHandler].[HANDLER-PATH].[_packageinfo_].[version]",
+                "condition": "$['config'].['requestHandler'].['${RH-HANDLER-PATH}'].['_packageinfo_'].['version']",
                 "expected": "${package-version}"
               }
             }


### PR DESCRIPTION
fixes the cause for https://issues.apache.org/jira/browse/SOLR-17072
impact is: false negative verification failure after successful package install.  