### PR TITLE
escape ' as "'" fix #85 $57

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,7 +89,7 @@ jobs:
                   "verify-command": {
                     "path": "/api/collections/${collection}/config/requestHandler?componentName=${RH-HANDLER-PATH}&meta=true",
                     "method": "GET",
-                    "condition": "$['config'].['requestHandler'].['${RH-HANDLER-PATH}'].['_packageinfo_'].['version']",
+                    "condition": "$['"'"'config'"'"'].['"'"'requestHandler'"'"'].['"'"'${RH-HANDLER-PATH}'"'"'].['"'"'_packageinfo_'"'"'].['"'"'version'"'"']",
                     "expected": "${package-version}"
                   }
                 }


### PR DESCRIPTION
here's how I checked it works

```
$echo '"condition": "$['"'"'config'"'"'].['"'"'requestHandler'"'"'].['"'"'${RH-HANDLER-PATH}'"'"'].['"'"'_packageinfo_'"'"'].['"'"'version'"'"']",'
"condition": "$['config'].['requestHandler'].['${RH-HANDLER-PATH}'].['_packageinfo_'].['version']",
```

fyi @risdenk